### PR TITLE
Fix for #129 - JPEGmini Sierra input name changed

### DIFF
--- a/bin/imageOptimAppleScriptLib
+++ b/bin/imageOptimAppleScriptLib
@@ -111,9 +111,9 @@ on runJPEGmini()
   (* NAVIGATE TO OUR FOLDER OF IMAGES *)
   tell application "System Events"
     tell process JPEGMINI_APP_NAME
-      set value of text field 1 of sheet 1 of sheet 1 of window 1 to DIRECTORY_JPG
+      set value of combo box 1 of sheet 1 of sheet 1 of window 1 to DIRECTORY_JPG
       repeat
-        if (value of text field 1 of sheet 1 of sheet 1 of window 1) is not equal to DIRECTORY_JPG then
+        if (value of combo box 1 of sheet 1 of sheet 1 of window 1) is not equal to DIRECTORY_JPG then
           delay 1
         else
           exit repeat

--- a/bin/imageOptimAppleScriptLib
+++ b/bin/imageOptimAppleScriptLib
@@ -111,14 +111,27 @@ on runJPEGmini()
   (* NAVIGATE TO OUR FOLDER OF IMAGES *)
   tell application "System Events"
     tell process JPEGMINI_APP_NAME
-      set value of combo box 1 of sheet 1 of sheet 1 of window 1 to DIRECTORY_JPG
-      repeat
-        if (value of combo box 1 of sheet 1 of sheet 1 of window 1) is not equal to DIRECTORY_JPG then
-          delay 1
-        else
-          exit repeat
-        end if
-      end repeat
+    (* DETERMINE THE FILE PATH SELECTOR OF JPEG MINI *)
+      set os_version to do shell script "sw_vers -productVersion | sed 's|\\.[0-9]\\{1,\\}$||g'"
+      if os_version is "10.12" then
+        set value of combo box 1 of sheet 1 of sheet 1 of window 1 to DIRECTORY_JPG
+        repeat
+          if (value of combo box 1 of sheet 1 of sheet 1 of window 1) is not equal to DIRECTORY_JPG then
+            delay 1
+          else
+            exit repeat
+          end if
+        end repeat
+      else
+        set value of text field 1 of sheet 1 of sheet 1 of window 1 to DIRECTORY_JPG
+        repeat
+          if (value of text field 1 of sheet 1 of sheet 1 of window 1) is not equal to DIRECTORY_JPG then
+            delay 1
+          else
+            exit repeat
+          end if
+        end repeat
+      end if
       -- give Finder time to resolve the path
       delay 2
       keystroke return


### PR DESCRIPTION
I was able to dig into the #129 Sierra issues. You're guide was super helpful @JamieMason, No idea why the UI elements changed names `¯\_(ツ)_/¯`

**UI Browser report**
<img width="290" alt="screen shot 2017-01-29 at 6 59 11 pm" src="https://cloud.githubusercontent.com/assets/330720/22409659/8c76d80e-e65b-11e6-9d6e-280d5fb69873.png">

**Versions Tested :** 
JPEGmini 1.9.9 (non pro)
macOS 10.12.3

