### PR TITLE
fix for multi-byte character

### DIFF
--- a/bin/imageOptimBashLib
+++ b/bin/imageOptimBashLib
@@ -325,7 +325,7 @@ function add_directory_option_to_index {
 # Remove any duplicate files in our index, which may have occurred when importing directories whose
 # images have already been gathered by other means.
 function remove_duplicate_indexes {
-  sort -uf "$INDEX_FILE"  > "$INDEX_FILE.uniq.txt"
+  LC_ALL=C sort -uf "$INDEX_FILE"  > "$INDEX_FILE.uniq.txt"
   mv "$INDEX_FILE.uniq.txt" "$INDEX_FILE"
 }
 


### PR DESCRIPTION
If multibyte characters are used as the file name of the image, all compression processing will not be executed. The result of sort is empty.

If multi-byte characters are included, srot will error
```
sort: string comparison failed: Illegal byte sequence
sort: Set LC_ALL='C' to work around the problem.
```



