### PR TITLE
Support Node >= 18.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install
         run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "5.1.6"
   },
   "engines": {
-    "node": "^18.0.0"
+    "node": ">=18"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Description (What)

Support later versions of Node instead of only 18.

## Justification (Why)

Closes #197.  Node 18 is in maintenance mode, and Node 20 is current.

## How Can This Be Tested?

Run `yarn`.