### PR TITLE
feat: add custom batch-sizing to cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Otherwise, you can install manually by downloading the latest release then addin
         --number-of-colors <n>  ImageAlpha palette size, defaults to 256
         --quality <min>-<max>   ImageAlpha quality range from 0-100, defaults to 65-80
         --speed <n>             ImageAlpha speed from 1 (brute-force) to 10 (fastest), defaults to 1
+        --batch-size <n>        set batch size for processing images, defaults to 300
         -h, --help              output usage information
 
       Supported Apps:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,6 +45,7 @@ export const VERSION = manifest.version;
 export const PNGQUANT_NUMBER_OF_COLORS = '256';
 export const PNGQUANT_QUALITY = '65-80';
 export const PNGQUANT_SPEED = '1';
+export const BATCH_SIZE = '300';
 export const PNGQUANT_BIN_PATH = '/Applications/ImageAlpha.app/Contents/MacOS/pngquant';
 export const IMAGEOPTIM_BIN_PATH = '/Applications/ImageOptim.app/Contents/MacOS/ImageOptim';
 

--- a/src/imageoptim.ts
+++ b/src/imageoptim.ts
@@ -4,6 +4,7 @@ import { sync } from 'globby';
 import { homedir } from 'os';
 import { cli } from './';
 import {
+  BATCH_SIZE,
   PNGQUANT_NUMBER_OF_COLORS,
   PNGQUANT_QUALITY,
   PNGQUANT_SPEED,
@@ -37,6 +38,10 @@ program
   .option(
     '--speed <n>',
     `ImageAlpha speed from 1 (brute-force) to 10 (fastest), defaults to ${PNGQUANT_SPEED}`,
+  )
+  .option(
+    '--batch-size <n>',
+    `batch size (lower this number for older machines), defaults to ${BATCH_SIZE}`,
   );
 
 program.on('--help', () => {
@@ -88,7 +93,7 @@ const filePaths = sync(patterns.map((pattern) => pattern.replace('~', homedir())
 const options = program.opts();
 
 cli({
-  batchSize: 300,
+  batchSize: options.batchSize || BATCH_SIZE,
   enabled: {
     color: options.color === true,
     imageAlpha: options.imagealpha === true,


### PR DESCRIPTION
<!--
All fields in this template are required.
-->

## Description (What)

added option for declaring custom batch sizes, ie: `--batch-size 5` , if no option is specified, the batch defaults to the original 300 count

## Justification (Why)

Older hardware experiences a regression of https://github.com/JamieMason/ImageOptim-CLI/issues/173

```
❯ imageoptim -V
3.1.9
```


```bash
❯ imageoptim .
i Running ImageOptim...
! stderr maxBuffer length exceeded

! Please raise an issue at https://github.com/JamieMason/ImageOptim-CLI/issues

    RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stderr maxBuffer length exceeded
        at new NodeError (node:internal/errors:388:5)
        at Socket.onChildStderr (node:child_process:476:14)
        at Socket.emit (node:events:537:28)
        at addChunk (node:internal/streams/readable:324:12)
        at readableAddChunk (node:internal/streams/readable:293:11)
        at Readable.push (node:internal/streams/readable:234:10)
        at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```        

on

```bash
❯ neofetch 
                    'c.          admin@mac-mini.local 
                 ,xNMM.          ---------------------- 
               .OMMMMo           OS: macOS 12.7.1 21G920 x86_64 
               OMMM0,            Host: Macmini7,1 
     .;loddo:' loolloddol;.      Kernel: 21.6.0 
   cKMMMMMMMMMMNWMMMMMMMMMM0:    Uptime: 5 hours, 3 mins 
 .KMMMMMMMMMMMMMMMMMMMMMMMWd.    Packages: 185 (brew) 
 XMMMMMMMMMMMMMMMMMMMMMMMX.      Shell: bash 5.2.21 
;MMMMMMMMMMMMMMMMMMMMMMMM:       Resolution: 1920x1080 
:MMMMMMMMMMMMMMMMMMMMMMMM:       DE: Aqua 
.MMMMMMMMMMMMMMMMMMMMMMMMX.      WM: Quartz Compositor 
 kMMMMMMMMMMMMMMMMMMMMMMMMWd.    WM Theme: Blue (Dark) 
 .XMMMMMMMMMMMMMMMMMMMMMMMMMMk   Terminal: Apple_Terminal 
  .XMMMMMMMMMMMMMMMMMMMMMMMMK.   Terminal Font: SFMono-Regular 
    kMMMMMMMMMMMMMMMMMMMMMMd     CPU: Intel i5-4278U (4) @ 2.60GHz 
     ;KMMMMMMMWXXWMMMMMMMk.      GPU: Intel Iris 
       .cooc,.    .,coo:.        Memory: 5274MiB / 8192MiB 
     
```


## How Can This Be Tested?

- [ ] test custom batch sizes

```bash
yarn build
./imageoptim --batch-size 10 ~/path/to/folder/
```
- [ ] test original settings 

```
./imageoptim ~/path/to/another/folder/
```