### PR TITLE
chore(build): also build arm executable for Apple's M1, M2, ..

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "repository": "JamieMason/ImageOptim-CLI",
   "scripts": {
     "build": "npm run build:ts && npm run build:bin",
-    "build:bin": "(cd dist && pkg --targets 'node18-macos-x64' --output ./imageoptim ./imageoptim.js)",
+    "build:bin": "(cd dist && pkg --targets 'node18-macos-x64,node18-macos-arm64' --output ./imageoptim ./imageoptim.js)",
     "build:ts": "tsc --project .",
     "format": "npm run format:imports && npm run format:prettier && npm run format:eslint",
     "format:eslint": "npm run lint -- --fix",


### PR DESCRIPTION

## Description (What)
This PR introduces support for creating ARM64 binaries, which are necessary for compatibility with Apple's M1 and M2 chips.

## Justification (Why)
This PR adds support for ARM64 binaries, making our application compatible with Apple's M1 and M2 chips. As more Mac users switch to these newer chips, thisupdate ensures that everyone can run our software efficiently.

This change will improve performance and energy use on the latest Mac models and keeps this package up-to-date with Apple's hardware advancements.


## How Can This Be Tested?
To ensure this update functions correctly, testing must be conducted on Apple devices with ARM64 processors (M1, M2 chips). ARM users can verify that the application runs natively and efficiently on their systems. Additionally, it's important to compile the application on x64 systems to confirm that the update hasn't affected compatibility with older Intel-based Macs. This dual approach will help confirm that our software remains functional and efficient across different hardware platforms.
